### PR TITLE
use new leapp_upgrade_type settings

### DIFF
--- a/analysis.yml
+++ b/analysis.yml
@@ -27,7 +27,8 @@
 
     - name: Ensure Leapp metadata is available for disconnected or RHUI Marketplace Leapp upgrades
       when: |
-        leapp_upgrade_type == 'disconnected' or
+        leapp_upgrade_type == 'satellite' or
+        leapp_upgrade_type == 'rhui' or
         (ansible_system_vendor == "Amazon EC2" and (ansible_product_uuid|regex_search('^ec2') or ansible_product_uuid|regex_search('^EC2')) and "'rhui' in yum_repolist.stdout") or
         (ansible_system_vendor == "Xen" and (ansible_product_uuid|regex_search('^ec2') or ansible_product_uuid|regex_search('^EC2')) and "'rhui' in yum_repolist.stdout")
       block:

--- a/group_vars/control/job_templates.yml
+++ b/group_vars/control/job_templates.yml
@@ -45,7 +45,7 @@ controller_templates:
           variable: ripu_pet_name
           required: false
     extra_vars:
-      leapp_upgrade_type: connected
+      leapp_upgrade_type: rhui
       leapp_metadata_url: https://host.location/leapp-data-21.tar.gz
       leapp_repos_enabled: []
     ask_variables_on_launch: true
@@ -70,7 +70,7 @@ controller_templates:
             - rhel9
           required: true
     extra_vars:
-      leapp_upgrade_type: connected
+      leapp_upgrade_type: rhui
       leapp_repos_enabled: []
     ask_variables_on_launch: true
   - name: AUTO / Remediation


### PR DESCRIPTION
Deal with new leapp_upgrade_type values changed with upstream ansible-leapp roles. Tested successfully in dev workshop. 