### PR TITLE
Use galaxy collection

### DIFF
--- a/analysis.yml
+++ b/analysis.yml
@@ -25,32 +25,6 @@
         - "'rhui' in yum_repolist.stdout"
         - ansible_distribution_major_version|int == 7
 
-    - name: Ensure Leapp metadata is available for disconnected/satellite or RHUI Marketplace Leapp upgrades
-      when: |
-        leapp_upgrade_type == 'satellite' or
-        (ansible_system_vendor == "Amazon EC2" and (ansible_product_uuid|regex_search('^ec2') or ansible_product_uuid|regex_search('^EC2')) and "'rhui' in yum_repolist.stdout") or
-        (ansible_system_vendor == "Xen" and (ansible_product_uuid|regex_search('^ec2') or ansible_product_uuid|regex_search('^EC2')) and "'rhui' in yum_repolist.stdout")
-      block:
-        - name: /etc/leapp/files directory exists
-          ansible.builtin.file:
-            path: /etc/leapp/files
-            state: directory
-            owner: root
-            group: root
-            mode: '0755'
-
-        - name: Leapp utility metadata is installed
-          ansible.builtin.unarchive:
-            src: "{{ leapp_metadata_url }}"
-            dest: /etc/leapp/files
-            remote_src: true
-            owner: root
-            group: root
-          register: leapp_metadata_installed
-          until: leapp_metadata_installed is not failed
-          retries: 10
-          delay: 10
-
     - name: Set analysis package list facts for preupgrade analysis for RHUI Marketplace Leapp upgrades
       ansible.builtin.set_fact:
         analysis_packages_el7:

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -12,9 +12,9 @@ collections:
 - name: infra.controller_configuration
   version: "2.3.1" # Version range identifiers (default: ``*``)
   source: https://galaxy.ansible.com # The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)
-- name: https://github.com/oamg/ansible-leapp.git
-  type: git
-  version: main
+- name: infra.leapp
+  version: "1.1.0" # Version range identifiers (default: ``*``)
+  source: https://galaxy.ansible.com # The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)
 - name: https://github.com/heatmiser/ansible-snapshot.git
   type: git
   version: main

--- a/group_vars/control/job_templates.yml
+++ b/group_vars/control/job_templates.yml
@@ -46,7 +46,6 @@ controller_templates:
           required: false
     extra_vars:
       leapp_upgrade_type: rhui
-      leapp_metadata_url: https://people.redhat.com/bmader/leapp-data-22.tar.gz
       leapp_repos_enabled: []
     ask_variables_on_launch: true
   - name: OS / Upgrade


### PR DESCRIPTION
@heatmiser, please review... 
- Pull infra.leapp (v1.1.0) from galaxy instead of using upstream git.
- Remove leapp_metadata_url as it's no longer needed. 