### PR TITLE
use --add option

### DIFF
--- a/remediate_rhel7.yml
+++ b/remediate_rhel7.yml
@@ -21,7 +21,7 @@
 - name: Remove pam_pkcs11 module # noqa command-instead-of-module
   ansible.builtin.shell: |
     set -o pipefail
-    leapp answer --section remove_pam_pkcs11_module_check.confirm=True
+    leapp answer --add --section remove_pam_pkcs11_module_check.confirm=True
   args:
     executable: /bin/bash
 

--- a/remediate_rhel7.yml
+++ b/remediate_rhel7.yml
@@ -6,6 +6,12 @@
     delay: 5
     timeout: 300
 
+- name: Install leapp
+  ansible.builtin.package:
+    name: leapp
+    enablerepo: rhel-7-server-rhui-extras-rpms
+    state: latest
+
 - name: Define kernel modules to unload
   ansible.builtin.set_fact:
     kernel_modules_to_unload:


### PR DESCRIPTION
The remediate playbook fails if it is run prior to the analysis playbook. This change fixes it. 