### PR TITLE
Add partition and physical volume resizing capabilities

### DIFF
--- a/group_vars/control/inventories.yml
+++ b/group_vars/control/inventories.yml
@@ -2,4 +2,8 @@
 controller_inventories:
   - name: Workshop Inventory
     organization: Default
+
+  - name: Demo Inventory
+    organization: Default
+    state: absent
 ...

--- a/group_vars/control/job_templates.yml
+++ b/group_vars/control/job_templates.yml
@@ -262,6 +262,30 @@ controller_templates:
           guid: "{{ lookup('env', 'AWX_HOST').split('.')[1] }}"
           Student: "{{ lookup('env', 'AWX_HOST').split('.')[0] | urlsplit('hostname') }}"
           operating_system: rhel
+  - name: UTILITY / Extend partition and resize physical volume
+    project: Project Leapp
+    playbook: partition_lvm_resize.yml
+    inventory: Workshop Inventory
+    credentials:
+      - Workshop Credential
+    survey_enabled: true
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: Select inventory group
+          type: multiplechoice
+          variable: rhel_inventory_group
+          choices:
+            - ALL_rhel
+            - rhel7
+            - rhel8
+            - rhel9
+          required: true
+    ask_limit_on_launch: true
+    extra_vars:
+      full_storage_device_name: /dev/nvme0n1
+      perform_resize: true
 
   - name: Demo Job Template
     state: absent

--- a/group_vars/control/job_templates.yml
+++ b/group_vars/control/job_templates.yml
@@ -262,4 +262,7 @@ controller_templates:
           guid: "{{ lookup('env', 'AWX_HOST').split('.')[1] }}"
           Student: "{{ lookup('env', 'AWX_HOST').split('.')[0] | urlsplit('hostname') }}"
           operating_system: rhel
+
+  - name: Demo Job Template
+    state: absent
 ...

--- a/partition_lvm_resize.yml
+++ b/partition_lvm_resize.yml
@@ -26,7 +26,9 @@
     - name: Resize physical volume to utilize all available space
       ansible.builtin.command: >-
         pvresize {{ full_storage_device_name }}p{{ storage_device_info.partitions | length }}
-      when: '"CHANGED" in growpart_output.stdout'
+      when:
+        - '"CHANGED" in growpart_output.stdout'
+        - perform_resize
       register: pvresize_output
 
     - name: Validate partition and physical volume resized

--- a/partition_lvm_resize.yml
+++ b/partition_lvm_resize.yml
@@ -13,11 +13,11 @@
         unit: MiB
       register: storage_device_info
 
-    - name: "{{ full_storage_device_name }}" device information
+    - name: "{{ full_storage_device_name }} device information"
       ansible.builtin.debug:
         var: storage_device_info
 
-    - name: Extend an existing partition to fill all available space
+    - name: Extend existing partition to fill all available space on device
       community.general.parted:
         device: "{{ full_storage_device_name }}"
         number: "{{ storage_device_info.partitions | length }}"

--- a/partition_lvm_resize.yml
+++ b/partition_lvm_resize.yml
@@ -18,11 +18,22 @@
         var: storage_device_info
 
     - name: Extend existing partition to fill all available space on device
-      community.general.parted:
-        device: "{{ full_storage_device_name }}"
-        number: "{{ storage_device_info.partitions | length }}"
-        part_end: "100%"
-        resize: true
-        state: present
+      ansible.builtin.command: >-
+        growpart {{ full_storage_device_name }} {{ storage_device_info.partitions | length }}
       when: perform_resize
+      register: growpart_output
+
+    - name: Resize physical volume to utilize all available space
+      ansible.builtin.command: >-
+        pvresize {{ full_storage_device_name }}p{{ storage_device_info.partitions | length }}
+      when: '"CHANGED" in growpart_output.stdout'
+      register: pvresize_output
+
+    - name: Validate partition and physical volume resized
+      ansible.builtin.assert:
+        that:
+          - 'full_storage_device_name ~ "p" ~ storage_device_info.partitions | length in pvresize_output.stdout'
+          - '"changed" in pvresize_output.stdout'
+        fail_msg: Failed to resize {{ full_storage_device_name }} partition {{ storage_device_info.partitions | length }} and physical volume {{ full_storage_device_name }}p{{ storage_device_info.partitions | length }}.
+        success_msg: Resized {{ full_storage_device_name }} partition {{ storage_device_info.partitions | length }} and physical volume {{ full_storage_device_name }}p{{ storage_device_info.partitions | length }}.
 ...

--- a/partition_lvm_resize.yml
+++ b/partition_lvm_resize.yml
@@ -1,0 +1,28 @@
+---
+- name: Extend partition and resize physical volume
+  hosts: "{{ rhel_inventory_group | default(omit) }}"
+  strategy: free
+  gather_facts: true
+  become: true
+  vars:
+    perform_resize: false
+  tasks:
+    - name: Read storage device information (always use unit when probing)
+      community.general.parted:
+        device: "{{ full_storage_device_name }}"
+        unit: MiB
+      register: storage_device_info
+
+    - name: "{{ full_storage_device_name }}" device information
+      ansible.builtin.debug:
+        var: storage_device_info
+
+    - name: Extend an existing partition to fill all available space
+      community.general.parted:
+        device: "{{ full_storage_device_name }}"
+        number: "{{ storage_device_info.partitions | length }}"
+        part_end: "100%"
+        resize: true
+        state: present
+      when: perform_resize
+...


### PR DESCRIPTION
Includes playbook that resizes partition and physical volume, along with accompanying job template CaC.
Also, Demo job template and Demo inventory removed via CaC