### PR TITLE
Snapshots update 2024-01-12

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -13,12 +13,12 @@ collections:
   version: "2.4.1" # Version range identifiers (default: ``*``)
   source: https://galaxy.ansible.com # The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)
 - name: infra.leapp
-  version: "1.1.3" # Version range identifiers (default: ``*``)
+  version: "1.1.4" # Version range identifiers (default: ``*``)
   source: https://galaxy.ansible.com # The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)
 - name: https://github.com/heatmiser/ansible-snapshot.git
   type: git
   version: main
-- name: https://github.com/swapdisk/lvm_snapshots.git
-  type: git
-  version: 1.0.3
+- name: infra.lvm_snapshots
+  version: "2.0.1" # Version range identifiers (default: ``*``)
+  source: https://galaxy.ansible.com # The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)
 ...

--- a/group_vars/control/job_templates.yml
+++ b/group_vars/control/job_templates.yml
@@ -120,11 +120,11 @@ controller_templates:
     credentials:
       - Workshop Credential
     extra_vars:
-      lvm_snapshots_set_name: ripu01
-      lvm_snapshots_snapshot_autoextend_threshold: 70
-      lvm_snapshots_snapshot_autoextend_percent: 20
-      lvm_snapshots_boot_backup: true
-      lvm_snapshots_volumes:
+      snapshot_create_set_name: ripu01
+      snapshot_create_snapshot_autoextend_threshold: 70
+      snapshot_create_snapshot_autoextend_percent: 20
+      snapshot_create_boot_backup: true
+      snapshot_create_volumes:
         - vg: VolGroup00
           lv: rootVol
           size: 3G

--- a/group_vars/control/job_templates.yml
+++ b/group_vars/control/job_templates.yml
@@ -120,7 +120,7 @@ controller_templates:
     credentials:
       - Workshop Credential
     extra_vars:
-      snapshot_create_set_name: ripu01
+      snapshot_set_name: ripu01
       snapshot_create_snapshot_autoextend_threshold: 70
       snapshot_create_snapshot_autoextend_percent: 20
       snapshot_create_boot_backup: true
@@ -169,9 +169,9 @@ controller_templates:
     credentials:
       - Workshop Credential
     extra_vars:
-      lvm_snapshots_set_name: ripu01
+      snapshot_set_name: ripu01
+      snapshot_create_boot_backup: true
       lvm_snapshots_action: revert
-      lvm_snapshots_boot_backup: true
     survey_enabled: true
     survey:
       name: ''

--- a/group_vars/control/job_templates.yml
+++ b/group_vars/control/job_templates.yml
@@ -283,6 +283,7 @@ controller_templates:
             - rhel9
           required: true
     ask_limit_on_launch: true
+    ask_variables_on_launch: true
     extra_vars:
       full_storage_device_name: /dev/nvme0n1
       perform_resize: true

--- a/partition_lvm_resize.yml
+++ b/partition_lvm_resize.yml
@@ -7,7 +7,7 @@
   vars:
     perform_resize: false
   tasks:
-    - name: Read storage device information (always use unit when probing)
+    - name: "Read {{ full_storage_device_name }} storage device information (always use unit when probing)"
       community.general.parted:
         device: "{{ full_storage_device_name }}"
         unit: MiB
@@ -17,18 +17,19 @@
       ansible.builtin.debug:
         var: storage_device_info
 
-    - name: "Add up partition sizes"
+    - name: "Calculate total partition usage on {{ full_storage_device_name }}"
       ansible.builtin.set_fact:
         total_partitions_size: "{{ total_partitions_size | default(0) | int + item.size | int }}"
       loop: "{{ storage_device_info.partitions }}"
       loop_control:
         label: "{{ item.num }}"
 
-    - name: "Compare total_partitions_size to storage_device_info.disk.size"
-      ansible.builtin.debug:
-        msg:
-          - "storage_device_info.disk.size: {{ storage_device_info.disk.size }}"
-          - "total_partitions_size: {{ total_partitions_size }}"
+    - name: "Validate total partition usage on {{ full_storage_device_name }} is less than total device size"
+      ansible.builtin.assert:
+        that:
+          - 'total_partitions_size | int + 1 < storage_device_info.disk.size'
+        fail_msg: Total partition usage on {{ full_storage_device_name }} equals total size of the device.
+        success_msg: Total partition usage on {{ full_storage_device_name }} is less than total size of the device.
 
     - name: Extend existing partition to fill all available space on device
       ansible.builtin.command: >-

--- a/partition_lvm_resize.yml
+++ b/partition_lvm_resize.yml
@@ -17,6 +17,19 @@
       ansible.builtin.debug:
         var: storage_device_info
 
+    - name: "Add up partition sizes"
+      ansible.builtin.set_fact:
+        total_partitions_size: "{{ total_partitions_size | default(0) | int + item.size | int }}"
+      loop: "{{ storage_device_info.partitions }}"
+      loop_control:
+        label: "{{ item.num }}"
+
+    - name: "Compare total_partitions_size to storage_device_info.disk.size"
+      ansible.builtin.debug:
+        msg:
+          - "storage_device_info.disk.size: {{ storage_device_info.disk.size }}"
+          - "total_partitions_size: {{ total_partitions_size }}"
+
     - name: Extend existing partition to fill all available space on device
       ansible.builtin.command: >-
         growpart {{ full_storage_device_name }} {{ storage_device_info.partitions | length }}

--- a/set_latest_kernel_default.yml
+++ b/set_latest_kernel_default.yml
@@ -1,0 +1,51 @@
+---
+- name: Set the latest kernel as default
+  hosts: "{{ rhel_inventory_group | default(omit) }}"
+  # gather_facts: true
+  gather_facts: false
+  become: true
+  strategy: free
+  tasks:
+    - name: Wait for connection...and gather facts
+      ansible.builtin.setup:
+        gather_timeout: 60
+      register: setup_result
+      ignore_errors: true
+      until: "setup_result is not failed"
+      retries: 10
+      delay: 10
+
+    - name: Capture path of the latest kernel vmlinuz
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          ls -1 /boot/vmlinuz-* |
+          tail -1
+      register: latest_vmlinuz
+      changed_when: false
+      failed_when:
+        - latest_vmlinuz.rc != 0
+        - latest_vmlinuz.stderr != ""
+
+    - name: Set latest kernel as default via grubby
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          grubby --set-default="{{ latest_vmlinuz.stdout }}"
+      register: set_grubby_default
+      changed_when: false
+      failed_when:
+        - set_grubby_default.rc != 0
+        - set_grubby_default.stderr != ""
+
+    - name: Reboot node
+      ansible.builtin.reboot:
+      register: reboot_result
+
+    - name: Wait for connection...
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 20
+        sleep: 5
+        delay: 5
+        timeout: 300
+...

--- a/snapshot_instance_lvm.yml
+++ b/snapshot_instance_lvm.yml
@@ -7,17 +7,22 @@
     LC_ALL: en_US.UTF-8
     TERM: linux
   tasks:
+    - ansible.builtin.set_fact:
+        snapshot_create_set_name: "{{ snapshot_set_name }}"
+        snapshot_remove_set_name: "{{ snapshot_set_name }}"
+        snapshot_revert_set_name: "{{ snapshot_set_name }}"
+
     - name: "Execute snapshot check"
       ansible.builtin.include_role:
         name: "infra.lvm_snapshots.snapshot_create"
-          # snapshot_* vars provided via AAP2 job template and associated surveys
       vars:
         snapshot_create_check_only: true
+        # Additional snapshot_* vars provided via AAP2 job template and associated surveys
       when: lvm_snapshots_action == "check"
 
     - name: "Execute snapshot {{ lvm_snapshots_action }}"
       ansible.builtin.include_role:
         name: "infra.lvm_snapshots.snapshot_{{ lvm_snapshots_action }}"
-          # snapshot_* vars provided via AAP2 job template and associated surveys
+        # Additional snapshot_* vars provided via AAP2 job template and associated surveys
       when: (lvm_snapshots_action == "create") or (lvm_snapshots_action == "remove") or (lvm_snapshots_action == "revert")
 ...

--- a/snapshot_instance_lvm.yml
+++ b/snapshot_instance_lvm.yml
@@ -1,12 +1,23 @@
 ---
-- name: Create/revert/remove LVM snapshot of node
+- name: Create/revert/remove/check LVM snapshots of node
   hosts: "{{ rhel_inventory_group | default(omit) }}"
   become: yes
   environment:
     LANG: en_US.UTF-8
     LC_ALL: en_US.UTF-8
     TERM: linux
-  roles:
-    - name: infra.lvm_snapshots.lvm_snapshots
-      # lvm_snapshot_* vars provided via AAP2 job template and associated surveys
+  tasks:
+    - name: "Execute snapshot check"
+      ansible.builtin.include_role:
+        name: "infra.lvm_snapshots.snapshot_create"
+          # snapshot_* vars provided via AAP2 job template and associated surveys
+      vars:
+        snapshot_create_check_only: true
+      when: lvm_snapshots_action == "check"
+
+    - name: "Execute snapshot {{ lvm_snapshots_action }}"
+      ansible.builtin.include_role:
+        name: "infra.lvm_snapshots.snapshot_{{ lvm_snapshots_action }}"
+          # snapshot_* vars provided via AAP2 job template and associated surveys
+      when: (lvm_snapshots_action == "create") or (lvm_snapshots_action == "remove") or (lvm_snapshots_action == "revert")
 ...


### PR DESCRIPTION
Updated collections:

- infra.leapp 1.1.4
- infra.lvm_snapshots 2.0.1

Updated snapshot_instance_lvm.yml playbook to utilize infra.lvm_snapshots v. 2.x, along with associated job template to utilize new variable naming.
Added additional logic to partition_lvm_resize.yml playbook to fail if no partition resizing can be performed.
Added new playbook for setting default kernel to most up to date version installed.

