### PR TITLE
Add tasks to send events

### DIFF
--- a/analysis.yml
+++ b/analysis.yml
@@ -51,4 +51,60 @@
         path: /var/log/leapp/answerfile
         regexp: '(\[check_vdo\][^<]*)\#\ confirm\ \='
         replace: '\1confirm\ \=\ True'
+
+    - name: Get report file status
+      ansible.builtin.stat:
+        path: /var/log/leapp/leapp-report.json
+      register: report_file
+
+    - name: Log preupgrade report
+      when: report_file.stat.exists and splunk_hectoken is defined
+      block:
+        - name: Gather EC2 metadata facts
+          amazon.aws.ec2_metadata_facts:
+          delegate_to: localhost
+          become: false
+          ignore_errors: true
+          when: ansible_system_vendor == "Amazon EC2" or ansible_system_vendor == "Xen"
+
+        - name: Collect JSON report results
+          ansible.builtin.slurp:
+            src: /var/log/leapp/leapp-report.json
+          register: leapp_report
+
+        - name: Assemble payload for Splunk
+          ansible.builtin.set_fact:
+            splunk_payload:
+              sourcetype: _json
+              index: "{{ splunk_index }}"
+              event:
+                event_type: leapp_report
+                hostname: "{{ ansible_facts.hostname }}"
+                job_id: "{{ awx_job_id | default('undefined') }}"
+                os_version: "{{ ansible_facts.distribution_version }}"
+                pet_app_env: "{{ ['Dev','Test','Prod'] | random(seed=ansible_facts.hostname) }}"
+                pet_app_team: "{{ ['Bird','Cat','Dog','Fish','Hamster','Lizard','Snake'] | random(seed=ansible_facts.hostname) }}"
+                region: "{{ ansible_ec2_placement_region | default('undefined') }}"
+                report: "{{ leapp_report.content | b64decode | from_json }}"
+
+        - name: Send event to Splunk
+          ansible.builtin.uri:
+            url: "{{ splunk_url }}"
+            headers:
+              Authorization: "Splunk {{ splunk_hectoken }}"
+            method: POST
+            body: "{{ splunk_payload }}"
+            body_format: json
+            return_content: true
+          delegate_to: localhost
+          become: false
+          changed_when: false
+          ignore_errors: true
+          register: splunk_send
+          no_log: true
+
+        - name: Show send result
+          ansible.builtin.debug:
+            var: splunk_send
+          when: splunk_send | default(false)
 ...

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -7,7 +7,57 @@
   # vars:
   #   ansible_python_interpreter: /usr/libexec/platform-python
   tasks:
-    - name: Perform OS upgrade
-      ansible.builtin.import_role:
-        name: infra.leapp.upgrade
+    - name: Upgrade block
+      block:
+        - name: Perform OS upgrade
+          ansible.builtin.import_role:
+            name: infra.leapp.upgrade
+
+      always:
+        - name: Log upgrade status
+          when: splunk_hectoken is defined
+          block:
+            - name: Gather EC2 metadata facts
+              amazon.aws.ec2_metadata_facts:
+              delegate_to: localhost
+              become: false
+              ignore_errors: true
+              when: ansible_system_vendor == "Amazon EC2" or ansible_system_vendor == "Xen"
+
+            - name: Assemble payload for Splunk
+              ansible.builtin.set_fact:
+                splunk_payload:
+                  sourcetype: _json
+                  index: "{{ splunk_index }}"
+                  event:
+                    event_type: playbook_run
+                    hostname: "{{ ansible_facts.hostname }}"
+                    job_id: "{{ awx_job_id | default('undefined') }}"
+                    os_version: "{{ ansible_facts.distribution_version }}"
+                    pet_app_env: "{{ ['Dev','Test','Prod'] | random(seed=ansible_facts.hostname) }}"
+                    pet_app_team: "{{ ['Bird','Cat','Dog','Fish','Hamster','Lizard','Snake'] | random(seed=ansible_facts.hostname) }}"
+                    region: "{{ ansible_ec2_placement_region | default('undefined') }}"
+                    play_name: "{{ ansible_play_name }}"
+                    success: "{{ leapp_upgrade_success | default(false) }}"
+
+            - name: Send event to Splunk
+              ansible.builtin.uri:
+                url: "{{ splunk_url }}"
+                headers:
+                  Authorization: "Splunk {{ splunk_hectoken }}"
+                method: POST
+                body: "{{ splunk_payload }}"
+                body_format: json
+                return_content: true
+              delegate_to: localhost
+              become: false
+              changed_when: false
+              ignore_errors: true
+              register: splunk_send
+              no_log: true
+
+            - name: Show send result
+              ansible.builtin.debug:
+                var: splunk_send
+              when: splunk_send | default(false)
 ...


### PR DESCRIPTION
This is just adding the tasks that will send events to Splunk when `splunk_hectoken` is defined. The configuration of the credential to set `splunk_hectoken` and related vars needs to happen during provisioning by agnosticv using the secret to be managed by demo dot.