### PR TITLE
Dev01 upgrade workflow 7-8-9

### DIFF
--- a/group_vars/control/job_templates.yml
+++ b/group_vars/control/job_templates.yml
@@ -192,7 +192,7 @@ controller_templates:
       snapshot_create_volumes:
         - vg: VolGroup00
           lv: rootVol
-          size: 3G
+          size: 4G
         - vg: VolGroup00
           lv: varVol
           size: 5G

--- a/group_vars/control/worflow_job_templates.yml
+++ b/group_vars/control/worflow_job_templates.yml
@@ -100,6 +100,60 @@ controller_workflows:
         all_parents_must_converge: false
         type: inventory_source
         success_nodes: []
+  - name: OS / Upgrade 7-8-9
+    description: Workflow for Snapshot and Leapp Upgrade 7-8 and 8-9
+    extra_vars:
+      lvm_snapshots_action: create
+    inventory: Workshop Inventory
+    state: present
+    organization: Default
+    survey_enabled: true
+    survey_spec:
+      name: ''
+      description: ''
+      spec:
+        - question_name: Select inventory group
+          question_description: Use to limit job to hosts that are members of the selected host group.
+          type: multiplechoice
+          default: ''
+          variable: rhel_inventory_group
+          choices:
+            - ALL_rhel
+            - rhel7
+            - rhel8
+            - rhel9
+          required: true
+    ask_limit_on_launch: true
+    simplified_workflow_nodes:
+      - identifier: UTILITY / Snapshot Instance
+        unified_job_template: UTILITY / Snapshot Instance
+        organization: Default
+        all_parents_must_converge: false
+        success_nodes:
+          - OS / Upgrade 7-8
+      - identifier: OS / Upgrade 7-8
+        unified_job_template: OS / Upgrade
+        organization: Default
+        all_parents_must_converge: false
+        success_nodes:
+          - OS / Remediation
+      - identifier: OS / Remediation
+        unified_job_template: OS / Remediation
+        organization: Default
+        all_parents_must_converge: false
+        success_nodes:
+          - OS / Analysis
+      - identifier: OS / Analysis
+        unified_job_template: AUTO / 01 Analysis
+        organization: Default
+        all_parents_must_converge: false
+        success_nodes:
+          - OS / Upgrade 8-9
+      - identifier: OS / Upgrade 8-9
+        unified_job_template: OS / Upgrade
+        organization: Default
+        all_parents_must_converge: false
+        success_nodes: []
   - name: Z / SETUP / Workshop deployment
     description: Workflow for workshop deployment
     inventory: Workshop Inventory


### PR DESCRIPTION
Successfully tested with the Summit LB1247 and Ansible BU workshop CIs. The Ansible BU workshop deploys with smaller disk size, but still had enough space for snapshoting both upgrades... 

```
  VG         #PV #LV #SN Attr   VSize  VFree  
  VolGroup00   1  11   4 wz--n- 31.53g 940.00m

  LV              VG         Attr       LSize   Pool Origin   Data%  Meta%  Move Log Cpy%Sync Convert
  auditVol_ripu01 VolGroup00 swi-a-s--- 100.00m      auditVol 8.39                                   
  logVol_ripu01   VolGroup00 swi-a-s--- 500.00m      logVol   8.70                                   
  rootVol_ripu01  VolGroup00 swi-a-s---   4.00g      rootVol  94.21                                  
  varVol_ripu01   VolGroup00 swi-a-s---  <6.03g      varVol   79.46                                  
```