### PR TITLE
Update syntax for firewalld.conf redmediation on RHEL 8

### DIFF
--- a/remediate_rhel8.yml
+++ b/remediate_rhel8.yml
@@ -15,7 +15,7 @@
   ansible.builtin.lineinfile:
     path: "/etc/firewalld/firewalld.conf"
     regex: "^(#)?{{ item.key }}"
-    line: "{{ item.key }} {{ item.value }}"
+    line: "{{ item.key }}={{ item.value }}"
     state: present
   loop:
     - {key: "AllowZoneDrifting", value: "no"}


### PR DESCRIPTION
Unlike `/etc/ssh/sshd_config` the firewalld configuration file `/etc/firewalld/firewalld.conf` uses the `=` character to separate keywords and arguments.  Here is a sample:

```
# grep -v \# /etc/firewalld/firewalld.conf  | grep -v ^$
DefaultZone=public
CleanupOnExit=yes
CleanupModulesOnExit=yes
Lockdown=no
IPv6_rpfilter=yes
IndividualCalls=no
LogDenied=off
FirewallBackend=nftables
FlushAllOnReload=yes
RFC3964_IPv4=yes
AllowZoneDrifting=yes
```

When running the playbook on a RHEL 8 host, the configuration file is updated with the following:
```
AllowZoneDrifting no
```

When restarting firewalld, the following is displayed:

```
Sep 11 14:21:14 client2 firewalld[46087]: ERROR: Invalid option definition: 'AllowZoneDrifting no'
Sep 11 14:21:14 client2 firewalld[46087]: WARNING: AllowZoneDrifting is enabled. This is considered an insecure configuration option. It will be removed in a future release. Please consider disabling it now.
```

This pull request alters the remediation so that `AllowZoneDrifting=no` is set in the configuration file.
