### PR TITLE
Install new cockpit-leapp package

### DIFF
--- a/controller_cockpit_setup.yml
+++ b/controller_cockpit_setup.yml
@@ -133,11 +133,13 @@
         enabled: false
 
     - name: Install Cockpit
-      ansible.builtin.package:
+      ansible.builtin.yum:
         name:
           - cockpit
           - cockpit-system
-        state: present
+          - cockpit-leapp
+        state: latest
+        enablerepo: leapp-supplements
 
     - name: Enable and start cockpit console service
       ansible.builtin.service:

--- a/controller_cockpit_setup.yml
+++ b/controller_cockpit_setup.yml
@@ -124,6 +124,14 @@
   become: true
   gather_facts: false
   tasks:
+    - name: Leapp custom actor repository
+      ansible.builtin.yum_repository:
+        name: leapp-supplements
+        description: Leapp custom actors for workshop demo
+        baseurl: https://people.redhat.com/bmader/leapp-supplements-demo/RHEL/$releasever/$basearch
+        gpgcheck: false
+        enabled: false
+
     - name: Install Cockpit
       ansible.builtin.package:
         name:
@@ -158,14 +166,6 @@
             name: atd.service
             enabled: true
             state: started
-
-        - name: Leapp custom actor repository
-          ansible.builtin.yum_repository:
-            name: leapp-supplements
-            description: Leapp custom actors for workshop demo
-            baseurl: https://people.redhat.com/bmader/leapp-supplements-demo/RHEL/$releasever/$basearch
-            gpgcheck: false
-            enabled: false
 
         - name: Set PasswordAuthentication no in sshd_config
           ansible.builtin.lineinfile:


### PR DESCRIPTION
The new cockpit-leapp package correctly displays pre-upgrade reports using schema 1.2.0. Since this package isn't GA yet, we'll install it from the leapp-supplements repo on my people page. 