### PR TITLE
don't install cockpit-leapp here

### DIFF
--- a/controller_cockpit_setup.yml
+++ b/controller_cockpit_setup.yml
@@ -137,9 +137,7 @@
         name:
           - cockpit
           - cockpit-system
-          - cockpit-leapp
         state: latest
-        enablerepo: leapp-supplements
 
     - name: Enable and start cockpit console service
       ansible.builtin.service:


### PR DESCRIPTION
This undoes my previously merged PR #50. The new `cockpit-leapp` package is GA now, so no need to install pre-release package from my people page repo.